### PR TITLE
Initialize projects page test and pom

### DIFF
--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect, Page } from "@playwright/test";
+import { ProjectsPage } from "../pom/projectsPage";
+import { login } from "../api/loginApi";
+
+test.beforeEach(async ({ page, baseURL }: { page: Page; baseURL?: string }) => {
+  if (!baseURL) {
+    throw new Error("baseURL is not defined");
+  }
+  await login(page, baseURL);
+
+  const projectsPage = new ProjectsPage(page);
+  await test.step("User starts in the Projects Page after login", async () => {
+    await page.goto(`${baseURL}/projects`);
+    await expect(page).toHaveURL(projectsPage.getProjectsPageUrl());
+  });
+});
+
+test("User is able to add a project", async ({ page }: { page: Page }) => {
+  const projectsPage = new ProjectsPage(page);
+  await test.step("User clicks on Add Project Button", async () => {
+    await projectsPage.getAddProjectButton().click();
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3000/',
+    baseURL: 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/pom/projectsPage.ts
+++ b/pom/projectsPage.ts
@@ -1,0 +1,21 @@
+import { Page } from "@playwright/test";
+
+export class ProjectsPage {
+  private readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async navigateToProjectsPage() {
+    await this.page.goto(this.getProjectsPageUrl());
+  }
+
+  getProjectsPageUrl() {
+    return "/projects";
+  }
+
+  getAddProjectButton() {
+    return this.page.getByRole("button", { name: "Add Project" });
+  }
+}


### PR DESCRIPTION
- Added a method to navigate to the Projects Page.

- Added a method to retrieve the "Add Project" button.
End-to-End Test Enhancements:

- Updated the test setup to ensure the user starts on the Projects Page after login.

- Added a test step to verify that the user can click the "Add Project" button.