### PR TITLE
Add project creation functionality with Faker for test data

### DIFF
--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, Page } from "@playwright/test";
 import { ProjectsPage } from "../pom/projectsPage";
 import { login } from "../api/loginApi";
+import { faker } from '@faker-js/faker';
 
 test.beforeEach(async ({ page, baseURL }: { page: Page; baseURL?: string }) => {
   if (!baseURL) {
@@ -9,15 +10,35 @@ test.beforeEach(async ({ page, baseURL }: { page: Page; baseURL?: string }) => {
   await login(page, baseURL);
 
   const projectsPage = new ProjectsPage(page);
-  await test.step("User starts in the Projects Page after login", async () => {
-    await page.goto(`${baseURL}/projects`);
+  await test.step("User is logged in via api and starts in the Projects Page", async () => {
     await expect(page).toHaveURL(projectsPage.getProjectsPageUrl());
   });
 });
 
 test("User is able to add a project", async ({ page }: { page: Page }) => {
   const projectsPage = new ProjectsPage(page);
+  const projectTitle = `${faker.lorem.words(3)} Title`;
+  const projectDescription = `${faker.lorem.sentence()} Description`;
+
   await test.step("User clicks on Add Project Button", async () => {
     await projectsPage.getAddProjectButton().click();
+  });
+
+  await test.step("User types project title", async () => {
+    await projectsPage.setProjectTitle().pressSequentially(projectTitle, { delay: 100 });
+  });
+
+  await test.step("User types project description", async () => {
+    await projectsPage.setProjectDescription().pressSequentially(projectDescription, { delay: 100 });
+  });
+
+  await test.step("User clicks accept button", async () => {
+    await projectsPage.getAcceptButton().click();
+  });
+
+  await test.step("Assert new project is visible in the Projects page", async () => {
+    await expect(page).toHaveURL(projectsPage.getProjectsPageUrl());
+    const projectCard = await projectsPage.findLastProjectCard(projectTitle);
+    expect(projectCard).not.toBeNull();
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@faker-js/faker": "^9.3.0",
         "@prisma/client": "^5.22.0",
         "@radix-ui/react-alert-dialog": "^1.0.2",
         "@radix-ui/react-avatar": "^1.0.1",
@@ -2753,6 +2754,22 @@
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.3.0.tgz",
+      "integrity": "sha512-r0tJ3ZOkMd9xsu3VRfqlFR6cz0V/jFYRswAIpC+m/DIfAUXq7g8N7wTAlhSANySXYGKzGryfDXwtwsY8TxEIDw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@fal-works/esbuild-plugin-global-externals": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "seed": "ts-node -r tsconfig-paths/register --compiler-options {\"module\":\"CommonJS\"} src/infrastructure/db/seed.ts"
   },
   "dependencies": {
+    "@faker-js/faker": "^9.3.0",
     "@prisma/client": "^5.22.0",
     "@radix-ui/react-alert-dialog": "^1.0.2",
     "@radix-ui/react-avatar": "^1.0.1",

--- a/pom/projectsPage.ts
+++ b/pom/projectsPage.ts
@@ -1,4 +1,4 @@
-import { Page } from "@playwright/test";
+import { Page, Locator } from "@playwright/test";
 
 export class ProjectsPage {
   private readonly page: Page;
@@ -7,15 +7,61 @@ export class ProjectsPage {
     this.page = page;
   }
 
-  async navigateToProjectsPage() {
-    await this.page.goto(this.getProjectsPageUrl());
-  }
-
-  getProjectsPageUrl() {
+  getProjectsPageUrl(): string {
     return "/projects";
   }
 
-  getAddProjectButton() {
+  getAddProjectButton(): Locator {
     return this.page.getByRole("button", { name: "Add Project" });
+  }
+
+  getNewProjectsPageUrl(): string {
+    return "/projects/new";
+  }
+
+  getUserAvatarButton(userInitials: string): Locator {
+    return this.page.getByText(userInitials);
+  }
+
+  getLogoutButton(): Locator {
+    return this.page.getByRole("button", { name: "Log out" });
+  }
+
+  getTitleField(): Locator {
+    return this.page.getByRole("textbox", { name: "Write the title" });
+  }
+
+  setProjectTitle(): Locator {
+    return this.getTitleField();
+  }
+
+  getDescriptionField(): Locator {
+    return this.page.getByRole("textbox", { name: "Add a description" });
+  }
+
+  setProjectDescription(): Locator {
+    return this.getDescriptionField();
+  }
+
+  getAcceptButton(): Locator {
+    return this.page.getByRole("button", { name: "Accept changes" });
+  }
+
+  getProjectsCard(): Locator {
+    return this.page.locator('a[href^="/projects/"]:not([href="/projects/new"])');
+  }
+
+  async findLastProjectCard(projectName: string): Promise<Locator | null> {
+    await this.getProjectsCard().last().waitFor();
+    const projectCards = this.getProjectsCard();
+    const projectCardsCount = await projectCards.count();
+    for (let i = 0; i < projectCardsCount; i++) {
+      const projectCard = projectCards.nth(i);
+      const projectCardText = await projectCard.textContent();
+      if (projectCardText?.includes(projectName)) {
+        return projectCard;
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
- Use of faker to randomize project titles and descriptions in the end-to-end tests.
- Test to verify user is able to create a project and assert it has been added to the projects page.