### PR TITLE
Reuse authentication state across tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ node_modules/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/playwright/.auth/*.json

--- a/api/loginApi.ts
+++ b/api/loginApi.ts
@@ -1,26 +1,23 @@
 import { Page } from "@playwright/test";
 import * as dotenv from "dotenv";
-
 dotenv.config();
 
 /**
  * Logs in to the application using the provided page and baseURL.
  *
  * @param {Page} page - The Playwright Page object to interact with.
- * @param {string} baseURL - The base URL of the application.
  * @param {string} [userId] - The user ID to log in with. Defaults to the value of the DS_USER_ID environment variable.
  * @returns {Promise<void>} A promise that resolves when the login process is complete.
  */
 export async function login(
-  page: Page, 
-  baseURL: string, 
+  page: Page,
   userId: string = process.env.DS_USER_ID ?? ""
 ): Promise<void> {
   if (!userId) {
     throw new Error("User ID is required for login");
   }
 
-  await page.request.post(`${baseURL}/login`, {
+  await page.request.post("/login", {
     form: {
       _data: "routes/login",
       user: userId,

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,16 @@
+import { test as setup } from "@playwright/test";
+import * as dotenv from "dotenv";
+dotenv.config();
+
+const authFile = "playwright/.auth/admin.json";
+
+setup("Admin Login", async ({ request }) => {
+  await request.post("/login", {
+    form: {
+      _data: "routes/login",
+      user: process.env.DS_USER_ID || "",
+      _action: "setUser",
+    },
+  });
+  await request.storageState({ path: authFile });
+});

--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -2,13 +2,8 @@ import { test, expect, Page } from "@playwright/test";
 import { LoginPage } from "../pom/loginPage";
 import { ProjectsPage } from "../pom/projectsPage";
 
-test("Login as default user", async ({
-  page,
-  baseURL,
-}: {
-  page: Page;
-  baseURL?: string;
-}): Promise<void> => {
+test.use({ storageState: { cookies: [], origins: [] } });
+test("Login as Default / Admin user", async ({ page }: { page: Page }): Promise<void> => {
   const loginPage = new LoginPage(page);
   const projectsPage = new ProjectsPage(page);
 

--- a/e2e/logout.spec.ts
+++ b/e2e/logout.spec.ts
@@ -1,16 +1,10 @@
 import { test, expect, Page } from "@playwright/test";
 import { ProjectsPage } from "../pom/projectsPage";
-import { login } from "../api/loginApi";
 import { LoginPage } from "../pom/loginPage";
 
-test.beforeEach(async ({ page, baseURL }: { page: Page; baseURL?: string }) => {
-  if (!baseURL) {
-    throw new Error("baseURL is not defined");
-  }
-  await login(page, baseURL);
-
+test.beforeEach(async ({ page }: { page: Page }) => {
   const projectsPage = new ProjectsPage(page);
-  await test.step("User is logged in via api and starts in the Projects Page", async (): Promise<void> => {
+  await test.step("User navigates to projects page", async (): Promise<void> => {
     await projectsPage.navigateTo();
     await expect(page).toHaveURL(projectsPage.getPageUrl());
   });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices } from "@playwright/test";
 
 /**
  * Read environment variables from file.
@@ -12,7 +12,7 @@ import { defineConfig, devices } from '@playwright/test';
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  testDir: process.env.TEST_DIR || './e2e', // or './tests-examples'
+  testDir: process.env.TEST_DIR || "./e2e", // or './tests-examples'
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -22,31 +22,38 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3000',
+    baseURL: "http://localhost:3000",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: "on-first-retry",
   },
 
   /* Configure projects for major browsers */
   projects: [
+    { name: "setup", testMatch: /.*\.setup\.ts/ },
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: "playwright/.auth/admin.json",
+      },
+      dependencies: ["setup"],
     },
 
     {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"], storageState: "playwright/.auth/admin.json" },
+      dependencies: ["setup"],
     },
 
     {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
+      name: "webkit",
+      use: { ...devices["Desktop Safari"], storageState: "playwright/.auth/admin.json" },
+      dependencies: ["setup"],
     },
 
     /* Test against mobile viewports. */


### PR DESCRIPTION
## Changes
Added API-driven authentication state management that:
- Creates authenticated session via API call in `auth.setup.ts`
- Stores auth state in `playwright/.auth/admin.json`
- Reuses auth state across test runs via project dependencies

## Benefits
- Eliminates repetitive UI login steps
- Reduces test execution time
- More stable than UI-based auth
- Prevents session timeouts during long test runs

## Implementation
1. Auth setup runs first via project dependency:
```ts
projects: [
  { name: "setup", testMatch: /.*\.setup\.ts/ },
  {
    name: "chromium",
    use: { storageState: "playwright/.auth/admin.json" },
    dependencies: ["setup"]
  }
]