### PR TITLE
Test to verify default projects cannot be deleted

### DIFF
--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -140,3 +140,14 @@ test("Project Owner is Able to Delete Project", async ({ page }: { page: Page })
     await expect(projectsPage.getProjectCardTitle(projectTitle)).not.toBeVisible();
   });
 });
+
+test("Unable to delete default projects", async ({ page }: { page: Page }) => {
+  const projectsPage = new ProjectsPage(page);
+
+  await test.step("Assert user is unable to delete default JIRA Clone project", async () => {
+    await expect(projectsPage.getDeleteProjectBtnStatus("JIRA Clone")).toBeDisabled();
+  });
+  await test.step("Assert user is unable to delete default Second project", async () => {
+    await expect(projectsPage.getDeleteProjectBtnStatus("Second Project")).toBeDisabled();
+  });
+});

--- a/pom/projectsPage.ts
+++ b/pom/projectsPage.ts
@@ -26,7 +26,7 @@ export class ProjectsPage {
     this.userCheckbox = page.getByRole("checkbox");
     this.logOutBtn = page.getByRole("button", { name: "Log out" });
     this.userAvatarBtn = page.getByTestId("user-avatar");
-    this.deleteProjectBtn = page.getByTitle("Delete project");
+    this.deleteProjectBtn = page.getByLabel("Open delete issue dialog");
     this.deleteIssueTxt = page.getByText("Delete issue?");
     this.confirmDeleteProjectBtn = page.getByRole("button", { name: "Delete" });
   }
@@ -72,6 +72,10 @@ export class ProjectsPage {
     return this.page.getByRole("heading", { name: projectTitle });
   }
 
+  getDeleteProjectBtnState(): Locator {
+    return this.deleteProjectBtn;
+  }
+
   async clickDeleteProjectBtn(projectTitle: string): Promise<void> {
     const projectCard = this.page
       .locator(`h2:has-text("${projectTitle}")`)
@@ -79,6 +83,15 @@ export class ProjectsPage {
       .locator("..")
       .locator("..");
     await projectCard.locator(this.deleteProjectBtn).click();
+  }
+
+  getDeleteProjectBtnStatus(projectTitle: string): Locator {
+    const projectCard = this.page
+      .locator(`h2:has-text("${projectTitle}")`)
+      .locator("..")
+      .locator("..")
+      .locator("..");
+    return projectCard.locator(this.getDeleteProjectBtnState());
   }
 
   getDeleteIssueModal(): Locator {


### PR DESCRIPTION
Added new E2E test that:
- Verifies default projects cannot be deleted
- Tests protection for both "JIRA Clone" and "Second Project"
- Validates delete button is disabled for default projects