### PR TITLE
Add Docker Compose installation step to build process

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,6 +16,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Install Docker Compose
+        run: |
+          sudo curl -L "https://github.com/docker/compose/releases/download/v2.20.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose --version  # Verify installation
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
Include a step to install Docker Compose in the Docker build workflow to ensure it is available for subsequent tasks.