### PR TITLE
Add Docker Compose service to GitHub workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -42,6 +42,12 @@ jobs:
           push: true
           tags: dramos84/jira-clone-tests:${{ github.sha }}
 
+      - name: Start Services with Docker Compose
+        run: docker-compose up -d
+
+      - name: Wait for Services to be Healthy
+        run: docker-compose run --rm app sh -c "while ! curl -sSf http://localhost:3000 > /dev/null; do sleep 5; done"
+
       - name: Run Playwright Tests in Docker (Using .env)
         run: |
           docker run --rm \
@@ -60,4 +66,3 @@ jobs:
           name: playwright-test-results
           path: playwright-report
           retention-days: 7
-


### PR DESCRIPTION
Integrate Docker Compose to start services and ensure they are healthy before running Playwright tests in the GitHub workflow.