### PR TITLE
Setup environment variables for GitHub Actions and Docker services

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -28,6 +28,14 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Create .env file
+        run: |
+          echo "SESSION_SECRET=${{ secrets.SESSION_SECRET }}" >> .env
+          echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> .env
+          echo "DS_USER_ID=${{ secrets.DS_USER_ID }}" >> .env
+          echo "AD_USER_ID=${{ secrets.AD_USER_ID }}" >> .env
+          echo "W_USER_ID=${{ secrets.W_USER_ID }}" >> .env
+
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get update && apt-get install -y \
 
 # Install dockerize (to wait for DB)
 RUN wget https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz && \
-    tar -xzvf dockerize-linux-amd64-v0.6.1.tar.gz -C /usr/local/bin && \
-    rm dockerize-linux-amd64-v0.6.1.tar.gz
+  tar -xzvf dockerize-linux-amd64-v0.6.1.tar.gz -C /usr/local/bin && \
+  rm dockerize-linux-amd64-v0.6.1.tar.gz
 
 # Set working directory inside container
 WORKDIR /app
@@ -35,5 +35,5 @@ RUN npx playwright install --with-deps
 # Expose the app port
 EXPOSE 3000
 
-# Start the app after DB is ready, then run tests
-CMD ["sh", "-c", "dockerize -wait tcp://jira_clone_db:5432 -timeout 60s && npm run setup-and-dev & sleep 30 && npx playwright test && tail -f /dev/null"]
+# Start the app after DB is ready
+CMD ["sh", "-c", "dockerize -wait tcp://jira_clone_db:5432 -timeout 60s && npm run setup-and-dev && tail -f /dev/null"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build: .
     env_file:
       - .env
+    environment:
+      DATABASE_URL: postgresql://jira_user:admin@jira_clone_db:5432/jira_clone_db
     depends_on:
       jira_clone_db:
         condition: service_healthy
@@ -10,9 +12,9 @@ services:
       - "3000:3000"
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:3000/ || exit 1"]
-      interval: 30s
+      interval: 10s
       timeout: 10s
-      retries: 3
+      retries: 5
       start_period: 30s
 
   jira_clone_db:
@@ -33,6 +35,8 @@ services:
     build: .
     env_file:
       - .env
+    environment:
+      DATABASE_URL: postgresql://jira_user:admin@jira_clone_db:5432/jira_clone_db
     depends_on:
       app:
         condition: service_healthy

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:3000",
+    baseURL: "http://app:3000", // Use the service name 'app' instead of 'localhost'
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",


### PR DESCRIPTION
Create a .env file during the GitHub Actions workflow to manage environment variables and update Docker service configurations for improved health checks and connectivity. Adjust Playwright configuration to use the service name instead of localhost.