### PR TITLE
Update dependencies to address security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,9 +65,15 @@
     "tailwindcss-radix-ui": "^0.0.4",
     "tiny-invariant": "^1.3.1",
     "uuid": "^8.3.2",
-    "vite": "^4.4.8",
+    "vite": ">=5.4.12",
     "vite-tsconfig-paths": "^3.5.2",
-    "vitest": "^0.24.5"
+    "vitest": "^0.24.5",
+    "path-to-regexp": ">=0.1.12",
+    "cross-spawn": ">=7.0.5",
+    "esbuild": ">=0.25.0",
+    "nanoid": ">=3.3.8",
+    "pnpm": ">=9.15.0",
+    "cookie": ">=0.7.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.49.0",
@@ -87,7 +93,7 @@
     "eslint": "^8.23.1",
     "eslint-plugin-storybook": "^0.6.13",
     "gh-pages": "^5.0.0",
-    "pnpm": "^9.11.0",
+    "pnpm": ">=9.15.0",
     "postcss": "^8.4.19",
     "prettier": "^2.7.1",
     "prettier-plugin-tailwindcss": "^0.1.13",
@@ -96,7 +102,13 @@
     "storybook": "^7.2.1",
     "tailwindcss": "^3.2.4",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.3"
+    "typescript": "^4.9.3",
+    "path-to-regexp": ">=0.1.12",
+    "cross-spawn": ">=7.0.5",
+    "esbuild": ">=0.25.0",
+    "vite": ">=5.4.12",
+    "nanoid": ">=3.3.8",
+    "cookie": ">=0.7.0"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
Update various dependencies to their minimum required versions to resolve security deadbot alerts.